### PR TITLE
refactor: remove unused helper function for replica descriptor

### DIFF
--- a/proto/varlogpb/metadata.go
+++ b/proto/varlogpb/metadata.go
@@ -116,30 +116,6 @@ func (r *ReplicaDescriptor) valid() bool {
 	return r != nil && len(r.StorageNodePath) != 0
 }
 
-func DiffReplicaDescriptorSet(xs []*ReplicaDescriptor, ys []*ReplicaDescriptor) []*ReplicaDescriptor {
-	xss := makeReplicaDescriptorDiffSet(xs)
-	yss := makeReplicaDescriptorDiffSet(ys)
-	for s := range yss {
-		delete(xss, s)
-	}
-	if len(xss) == 0 {
-		return nil
-	}
-	ret := make([]*ReplicaDescriptor, 0, len(xss))
-	for _, x := range xss {
-		ret = append(ret, x)
-	}
-	return ret
-}
-
-func makeReplicaDescriptorDiffSet(replicas []*ReplicaDescriptor) map[string]*ReplicaDescriptor {
-	set := make(map[string]*ReplicaDescriptor, len(replicas))
-	for _, replica := range replicas {
-		set[replica.String()] = replica
-	}
-	return set
-}
-
 func (m *MetadataDescriptor) Must() *MetadataDescriptor {
 	if m == nil {
 		panic("MetadataDescriptor is nil")

--- a/proto/varlogpb/metadata_test.go
+++ b/proto/varlogpb/metadata_test.go
@@ -1,8 +1,6 @@
 package varlogpb
 
 import (
-	"sort"
-	"strconv"
 	"testing"
 )
 
@@ -38,35 +36,4 @@ func TestLogStreamStatus(t *testing.T) {
 			}
 		})
 	}
-}
-
-func TestDiffReplicaDescriptorSet(t *testing.T) {
-	var tests []struct {
-		xs       []*ReplicaDescriptor
-		ys       []*ReplicaDescriptor
-		expected []*ReplicaDescriptor
-	}
-
-	for i := range tests {
-		test := tests[i]
-		t.Run(strconv.Itoa(i), func(t *testing.T) {
-			actual := DiffReplicaDescriptorSet(test.xs, test.ys)
-			if len(actual) != len(test.expected) {
-				t.Error("size mismatch")
-			}
-			sort.Slice(actual, func(i, j int) bool {
-				return actual[i].String() < actual[j].String()
-			})
-			sort.Slice(test.expected, func(i, j int) bool {
-				return test.expected[i].String() < test.expected[j].String()
-			})
-			for i := 0; i < len(actual); i++ {
-				x, y := actual[i], test.expected[i]
-				if !x.Equal(y) {
-					t.Errorf("inequal element: actual=%v expected=%v", x.String(), y.String())
-				}
-			}
-		})
-	}
-
 }


### PR DESCRIPTION
### What this PR does

This patch removes unused function - `proto/varlogpb.DiffReplicaDescriptorSet`.

### Which issue(s) this PR resolves

### Anything else

